### PR TITLE
Update mobile nav menu to slide in from the left

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -29,6 +29,8 @@ export default function Header({
           <span className="moon-icon">🌙</span>
         </button>
 
+        <div className={`nav-overlay ${isMenuOpen ? "open" : ""}`} onClick={onToggleMenu}></div>
+
         <ul className={`header-dropdown ${isMenuOpen ? "open" : ""}`} id="myDropdown" role="menu">
           {navItems.map((item) => (
             <li key={item.href} role="none">

--- a/app/globals.css
+++ b/app/globals.css
@@ -436,6 +436,7 @@ body.dark-mode .dark-mode-toggle .moon-icon {
   z-index: 999;
   flex-direction: column;
   background: var(--Color-1);
+  opacity: 0.95;
   position: fixed;
   top: 0;
   bottom: 0;
@@ -445,7 +446,6 @@ body.dark-mode .dark-mode-toggle .moon-icon {
   transform: translateX(-100%);
   transition: transform 0.3s ease;
   padding-top: 5rem;
-  opacity: 1 !important;
 }
 
 .header-dropdown.open {

--- a/app/globals.css
+++ b/app/globals.css
@@ -425,7 +425,7 @@ body.dark-mode .dark-mode-toggle .moon-icon {
   left: 0;
   right: 0;
   box-shadow: var(--Shadow-Lg);
-  animation: slideDown 0.3s ease;
+  animation: slideInLeft 0.3s ease;
   border-bottom: 1px solid var(--Color-Surface-Border);
 }
 
@@ -435,6 +435,11 @@ body.dark-mode .dark-mode-toggle .moon-icon {
 
 @keyframes slideInRight {
   from { opacity: 0; transform: translateX(20px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes slideInLeft {
+  from { opacity: 0; transform: translateX(-100%); }
   to { opacity: 1; transform: translateX(0); }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -413,33 +413,47 @@ body.dark-mode .dark-mode-toggle .moon-icon {
    Dropdown Menu
    ============================ */
 
+.nav-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+  z-index: 998;
+}
+
+.nav-overlay.open {
+  opacity: 1;
+  visibility: visible;
+}
+
 .header-dropdown {
-  display: none;
+  display: flex;
   z-index: 999;
   flex-direction: column;
-  background: var(--Color-Surface);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  background: var(--Color-1);
   position: fixed;
-  top: 4rem;
+  top: 0;
+  bottom: 0;
   left: 0;
-  right: 0;
+  width: 250px;
   box-shadow: var(--Shadow-Lg);
-  animation: slideInLeft 0.3s ease;
-  border-bottom: 1px solid var(--Color-Surface-Border);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  padding-top: 5rem;
+  opacity: 1 !important;
 }
 
 .header-dropdown.open {
-  display: flex;
+  transform: translateX(0);
 }
 
 @keyframes slideInRight {
   from { opacity: 0; transform: translateX(20px); }
-  to { opacity: 1; transform: translateX(0); }
-}
-
-@keyframes slideInLeft {
-  from { opacity: 0; transform: translateX(-100%); }
   to { opacity: 1; transform: translateX(0); }
 }
 
@@ -1537,6 +1551,10 @@ a:has(img):focus-visible {
     padding: 0.875rem 3rem;
   }
 
+  .nav-overlay {
+    display: none;
+  }
+
   .header-dropdown {
     position: static;
     display: flex !important;
@@ -1547,6 +1565,9 @@ a:has(img):focus-visible {
     backdrop-filter: none;
     box-shadow: none;
     border: none;
+    transform: translateX(0);
+    padding-top: 0;
+    width: auto;
   }
 
   .header-dropdown li {


### PR DESCRIPTION
Updates the mobile navigation menu animation to slide in from the left instead of sliding down from the top.

* Modifies `app/globals.css` to use `animation: slideInLeft 0.3s ease;` for `.header-dropdown`.
* Defines the new `@keyframes slideInLeft` moving opacity and translate from `-100%` to `0`.

---
*PR created automatically by Jules for task [7446694477703749054](https://jules.google.com/task/7446694477703749054) started by @dixonsilveroff*